### PR TITLE
Add seek-ability to progress bar

### DIFF
--- a/src/components/embedPlayer.jsx
+++ b/src/components/embedPlayer.jsx
@@ -51,11 +51,12 @@ export default function EmbedPlayer(props) {
 
   const reactPlayer = useRef();
   const onSeekHandler = (event) => {
-    const progressBarWidth = document.getElementById('progressBar').offsetWidth;
-    const clickXPosition = event.clientX - 12 // 12 pixels of padding + margin on the left
+    const progressBarWidth = document.getElementById("progressBar").offsetWidth;
+    const clickXPosition = event.clientX - 12; // 12 pixels of padding + margin on the left
     const targetSeek = clickXPosition / progressBarWidth;
-    reactPlayer.current.seekTo(targetSeek)
-  }
+    reactPlayer.current.seekTo(targetSeek);
+  };
+
   const { trackData } = props;
 
   const trackDataLength = trackData.length - 1;
@@ -147,7 +148,12 @@ export default function EmbedPlayer(props) {
                   by {trackData[currentTrackIndex].artist}
                 </p>
                 {/* PROGRESS BAR */}
-                <div className="h-3" id="progressBar" ref={progressBarRef} onClick={onSeekHandler}>
+                <div
+                  className="h-3"
+                  id="progressBar"
+                  ref={progressBarRef}
+                  onClick={onSeekHandler}
+                >
                   <div className="my-2 border-b-2 border-brand-pink pt-2" />
                 </div>
                 {/* Overlay */}

--- a/src/components/embedPlayer.jsx
+++ b/src/components/embedPlayer.jsx
@@ -15,7 +15,7 @@ import ReactPlayer from "react-player";
 const shareUrl = process.env.NEXT_PUBLIC_DOMAIN_URL;
 
 export default function EmbedPlayer(props) {
-  const ref = useRef(null);
+  const progressBarRef = useRef(null);
 
   // Hydration fix for ReactPlayer & React 18
   const [hasWindow, setHasWindow] = useState(false);
@@ -44,11 +44,18 @@ export default function EmbedPlayer(props) {
     if (typeof window.webln === "undefined") {
       setWebLnAvailable(false);
     }
-    if (ref.current) {
-      setWidth(ref.current.offsetWidth);
+    if (progressBarRef.current) {
+      setWidth(progressBarRef.current.offsetWidth);
     }
   }, []);
 
+  const reactPlayer = useRef();
+  const onSeekHandler = (event) => {
+    const progressBarWidth = document.getElementById('progressBar').offsetWidth;
+    const clickXPosition = event.clientX - 12 // 12 pixels of padding + margin on the left
+    const targetSeek = clickXPosition / progressBarWidth;
+    reactPlayer.current.seekTo(targetSeek)
+  }
   const { trackData } = props;
 
   const trackDataLength = trackData.length - 1;
@@ -140,10 +147,12 @@ export default function EmbedPlayer(props) {
                   by {trackData[currentTrackIndex].artist}
                 </p>
                 {/* PROGRESS BAR */}
-                <div className="my-2 border-b-2 border-brand-pink" ref={ref} />
+                <div className="h-3" id="progressBar" ref={progressBarRef} onClick={onSeekHandler}>
+                  <div className="my-2 border-b-2 border-brand-pink pt-2" />
+                </div>
                 {/* Overlay */}
                 <div
-                  className="relative z-10 -translate-y-2.5 border-b-2 border-brand-pink-dark"
+                  className="relative z-10 -translate-y-2 border-b-2 border-brand-pink-dark"
                   style={{
                     width: `${trackProgress}%`,
                     transitionProperty: "width",
@@ -244,6 +253,7 @@ export default function EmbedPlayer(props) {
       )}
       {hasWindow && trackData.length > 0 && (
         <ReactPlayer
+          ref={reactPlayer}
           controls={false}
           url={trackData[currentTrackIndex].liveUrl}
           playing={isPlaying}

--- a/src/components/embedPlayer.jsx
+++ b/src/components/embedPlayer.jsx
@@ -154,7 +154,7 @@ export default function EmbedPlayer(props) {
                   ref={progressBarRef}
                   onClick={onSeekHandler}
                 >
-                  <div className="my-2 border-b-2 border-brand-pink pt-2" />
+                  <div className="my-2 border-b-2 border-brand-pink pt-1" />
                 </div>
                 {/* Overlay */}
                 <div


### PR DESCRIPTION
I tapped into the `seekTo` of `react-player` to implement a clickable progress bar.

I increased the height of the clickable area so the bar is more easily clicked.

https://user-images.githubusercontent.com/14062229/228974090-8fd0b6cd-1b60-4394-9f96-55988c7b4855.mov

